### PR TITLE
Update UIntX library

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+# About
+_Give a quick summary on what are you proposing with this PR_
+
+# How 
+_The technical discussion on how you've achieved the proposed change_
+
+# Is it a breaking change?
+_Yes/No - may give a brief explanation as well_
+
+# Related issue [optional]
+_A link to the related issue_

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/rkreutz/UIntX",
         "state": {
           "branch": null,
-          "revision": "bd6f2f563a7c23b42cf16449e31d3cbc983edb09",
-          "version": "1.0.1"
+          "revision": "96954c1534f00fd4776f86e4731299d77c2dfe59",
+          "version": "2.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -79,7 +79,7 @@ let package = Package(
     products: products,
     dependencies: [
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/rkreutz/UIntX", .upToNextMajor(from: "1.0.1")),
+        .package(url: "https://github.com/rkreutz/UIntX", .upToNextMajor(from: "2.0.0")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.0.1"))
     ],
     targets: targets,

--- a/Sources/CLI/PasswordGeneratorCLI.swift
+++ b/Sources/CLI/PasswordGeneratorCLI.swift
@@ -4,10 +4,10 @@ struct PasswordGeneratorCLI: ParsableCommand {
 
     struct Options: ParsableArguments {
 
-        @Option(name: .long, default: 100, help: "The number of iterations to be used to generate a PBKDF2 key")
+        @Option(name: .long, default: 1_000, help: "The number of iterations to be used to generate a PBKDF2 key")
         var keyIterations: Int
 
-        @Option(name: .long, default: 8, help: "The size in bytes of the PBKDF2 key")
+        @Option(name: .long, default: 64, help: "The size in bytes of the PBKDF2 key")
         var keyLength: Int
         
         @Option(name: .shortAndLong, help: "The master password to be used")

--- a/Sources/PasswordGeneratorKit/PasswordGenerator.swift
+++ b/Sources/PasswordGeneratorKit/PasswordGenerator.swift
@@ -5,8 +5,8 @@ public final class PasswordGenerator {
     private let passwordGenerator: GenericPasswordGenerator<UIntX64>
 
     public init(masterPasswordProvider: MasterPasswordProvider,
-                iterations: Int = 100,
-                bytes: Int = 8) {
+                iterations: Int = 1_000,
+                bytes: Int = 64) {
 
         self.passwordGenerator = GenericPasswordGenerator<UIntX64>(
             masterPasswordProvider: masterPasswordProvider,

--- a/Tests/PasswordGeneratorKitTests/EntropyGeneratorTests.swift
+++ b/Tests/PasswordGeneratorKitTests/EntropyGeneratorTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import PasswordGeneratorKit
+
+final class EntropyGeneratorTests: XCTestCase {
+
+    func testPBKDF2EntropyGeneration() {
+
+        let generator = PBKDF2BasedEntropyGenerator<UInt64>(iterations: 1, bytes: 8)
+        let entropy = try? generator.generateEntropy(with: "salt", masterPassword: "password")
+        XCTAssertEqual(entropy?.bitWidth, 64)
+
+        let generator2 = PBKDF2BasedEntropyGenerator<UInt64>(iterations: 1, bytes: 16)
+        let entropy2 = try? generator2.generateEntropy(with: "salt", masterPassword: "password")
+        XCTAssertEqual(entropy2?.bitWidth, 128)
+
+        let generator3 = PBKDF2BasedEntropyGenerator<UInt64>(iterations: 1, bytes: 20)
+        let entropy3 = try? generator3.generateEntropy(with: "salt", masterPassword: "password")
+        XCTAssertEqual(entropy3?.bitWidth, 192)
+
+        let generator4 = PBKDF2BasedEntropyGenerator<UInt8>(iterations: 1, bytes: 32)
+        let entropy4 = try? generator4.generateEntropy(with: "salt", masterPassword: "password")
+        XCTAssertEqual(entropy4?.bitWidth, 256)
+    }
+
+    static let allTests = [
+        ("testPBKDF2EntropyGeneration", testPBKDF2EntropyGeneration)
+    ]
+}

--- a/Tests/PasswordGeneratorKitTests/PasswordGeneratorTests.swift
+++ b/Tests/PasswordGeneratorKitTests/PasswordGeneratorTests.swift
@@ -9,7 +9,7 @@ final class PasswordGeneratorTests: XCTestCase {
 
         XCTAssertEqual(
             try generator.generatePassword(salt: "salt", rules: PasswordRule.defaultRules),
-            "KNn&8Rf-s@V%wq8@"
+            "K-T#Mq1$MvQ4@%6l"
         )
     }
 
@@ -24,7 +24,7 @@ final class PasswordGeneratorTests: XCTestCase {
                 seed: 1,
                 rules: PasswordRule.defaultRules
             ),
-            "qtYSYWdB?.4rSM&9"
+            "L5bnoSNxy5OZ_6LE"
         )
 
         XCTAssertEqual(
@@ -34,7 +34,7 @@ final class PasswordGeneratorTests: XCTestCase {
                 seed: 2,
                 rules: PasswordRule.defaultRules
             ),
-            "7Ut39lh|K5@UVvSz"
+            "&qilq&O_M.J&oR11"
         )
     }
 
@@ -44,7 +44,7 @@ final class PasswordGeneratorTests: XCTestCase {
 
         XCTAssertEqual(
             try generator.generatePassword(service: "Bank name", rules: PasswordRule.defaultRules),
-            "au1_m-_Ix-hkayw9"
+            "Aekve?RLjcc4XD8!"
         )
     }
 
@@ -86,7 +86,7 @@ final class PasswordGeneratorTests: XCTestCase {
                     .mustContain(characterSet: String.symbolCharacters, atLeast: 1)
                 ]
             ),
-            "ojCgeH8B8&"
+            "YLWnz4r@7b"
         )
 
         XCTAssertEqual(
@@ -97,7 +97,7 @@ final class PasswordGeneratorTests: XCTestCase {
                     .mustContain(characterSet: String.decimalCharacters, atLeast: 0)
                 ]
             ),
-            "7249"
+            "3979"
         )
     }
 

--- a/Tests/PasswordGeneratorKitTests/PerformanceTests.swift
+++ b/Tests/PasswordGeneratorKitTests/PerformanceTests.swift
@@ -10,7 +10,7 @@ final class PerformanceTests: XCTestCase {
             masterPasswordProvider: "masterPassword",
             entropyGenerator: PBKDF2BasedEntropyGenerator(
                 iterations: 1_000,
-                bytes: 4
+                bytes: 32
             )
         )
 
@@ -23,7 +23,7 @@ final class PerformanceTests: XCTestCase {
                     seed: 1,
                     rules: PasswordRule.defaultCharacterSet.union([PasswordRule.length(32)])
                 ),
-                "nEO7cM?Za%x682Ta0iNPbO9er6vsekY?"
+                "D&Wij1OxF-row84yvsz8BYE3UnmV3B%Q"
             )
         }
     }
@@ -34,7 +34,7 @@ final class PerformanceTests: XCTestCase {
             masterPasswordProvider: "masterPassword",
             entropyGenerator: PBKDF2BasedEntropyGenerator(
                 iterations: 100,
-                bytes: 8
+                bytes: 64
             )
         )
 
@@ -47,7 +47,7 @@ final class PerformanceTests: XCTestCase {
                     seed: 1,
                     rules: PasswordRule.defaultCharacterSet.union([PasswordRule.length(32)])
                 ),
-                "tYSYWdB?4rSq&89I.|Z|Ul0ITql1MHCK"
+                "yPGPRraFcXJ!Tk%1H3ib8RttZ0dZK#v!"
             )
         }
     }

--- a/Tests/PasswordGeneratorKitTests/XCTestManifests.swift
+++ b/Tests/PasswordGeneratorKitTests/XCTestManifests.swift
@@ -3,6 +3,7 @@ import XCTest
 #if !canImport(ObjectiveC)
 public func allTests() -> [XCTestCaseEntry] {
     [
+        testCase(EntropyGeneratorTests.allTests),
         testCase(PasswordGeneratorTests.allTests),
         testCase(GenericPasswordGeneratorTests.allTests),
         testCase(PerformanceTests.allTests)


### PR DESCRIPTION
# About
Updating `UIntX` library.

 # How 
There was a change on `UIntX`, where initialisation of a `UIntX` value will respect the size of the input (number of bytes), that way generating PBKDF2 keys actually make sense, since the number of bytes of the key will translate into the number of bytes of our generated entropy, whereas before the number of bytes of our entropy would be determined by the type of the internal value instead.

Having that said, default size of the PBKDF2 key was changed from 8 bytes to 64 bytes, which will generate an entropy of the same magnitude as before (before 8 elements in an array * 8 bytes per element equal to 64 bytes).

 # Is it a breaking change?
Yes. API is not broken, but the behaviour will change, since we've changed how our entropy will be generated, passwords will be generated differently as well.