### PR TITLE
Adding Argon2 based entropy generator

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,12 +2,21 @@
   "object": {
     "pins": [
       {
+        "package": "Argon2Kit",
+        "repositoryURL": "https://github.com/rkreutz/Argon2Kit",
+        "state": {
+          "branch": null,
+          "revision": "87b9ca9c42304b8c6a5c14d7f6d6a0342917e71c",
+          "version": "0.1.1"
+        }
+      },
+      {
         "package": "CryptoSwift",
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift",
         "state": {
           "branch": null,
-          "revision": "39f08ac5269361a50c08ce1e2f41989bfc4b1ec8",
-          "version": "1.3.1"
+          "revision": "19b3c3ceed117c5cc883517c4e658548315ba70b",
+          "version": "1.6.0"
         }
       },
       {
@@ -15,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "8d31a0905c346a45c87773ad50862b5b3df8dff6",
-          "version": "0.0.4"
+          "revision": "223d62adc52d51669ae2ee19bdb8b7d9fd6fcd9c",
+          "version": "0.0.6"
         }
       },
       {
@@ -24,8 +33,8 @@
         "repositoryURL": "https://github.com/rkreutz/UIntX",
         "state": {
           "branch": null,
-          "revision": "96954c1534f00fd4776f86e4731299d77c2dfe59",
-          "version": "2.0.0"
+          "revision": "af0adb198db9a61a3c15a8d095941ba7b4712414",
+          "version": "3.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ var products: [Product] = [
 var targets: [Target] = [
     .target(
         name: "PasswordGeneratorKit",
-        dependencies: ["CryptoSwift", "UIntX"]
+        dependencies: ["CryptoSwift", "UIntX", "Argon2Kit"]
     ),
     .target(
         name: "CLI",
@@ -64,8 +64,9 @@ let package = Package(
     products: products,
     dependencies: [
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/rkreutz/UIntX", .upToNextMajor(from: "2.0.0")),
-        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.0.1"))
+        .package(url: "https://github.com/rkreutz/UIntX", .upToNextMajor(from: "3.0.0")),
+        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.0.1")),
+        .package(url: "https://github.com/rkreutz/Argon2Kit", .upToNextMajor(from: "0.1.1"))
     ],
     targets: targets,
     swiftLanguageVersions: [.v5]

--- a/Sources/CLI/AllowedCharacters.swift
+++ b/Sources/CLI/AllowedCharacters.swift
@@ -1,39 +1,28 @@
 import ArgumentParser
-@testable import PasswordGeneratorKit
+import PasswordGeneratorKit
 
-public enum AllowedCharacters: String, CaseIterable, ExpressibleByArgument, CustomStringConvertible {
+public enum AllowedCharacters: String, EnumerableFlag {
 
     case lowercase
     case uppercase
     case decimal
     case symbols
 
-    public var description: String { rawValue }
-
     func asPasswordRule() -> PasswordRule {
 
         switch self {
 
         case .lowercase:
-            return .mustContain(characterSet: String.lowercaseCharacters, atLeast: 1)
+            return .mustContain(characterSet: PasswordRule.CharacterSet.lowercase, atLeast: 1)
 
         case .uppercase:
-            return .mustContain(characterSet: String.uppercaseCharacters, atLeast: 1)
+            return .mustContain(characterSet: PasswordRule.CharacterSet.uppercase, atLeast: 1)
 
         case .symbols:
-            return .mustContain(characterSet: String.symbolCharacters, atLeast: 1)
+            return .mustContain(characterSet: PasswordRule.CharacterSet.symbol, atLeast: 1)
             
         case .decimal:
-            return .mustContain(characterSet: String.decimalCharacters, atLeast: 1)
+            return .mustContain(characterSet: PasswordRule.CharacterSet.decimal, atLeast: 1)
         }
-    }
-}
-
-extension Array: ExpressibleByArgument where Element == AllowedCharacters {
-
-    public init?(argument: String) {
-
-        guard let allowedCharacters = AllowedCharacters(argument: argument) else { return nil }
-        self = [allowedCharacters]
     }
 }

--- a/Sources/CLI/DomainBased.swift
+++ b/Sources/CLI/DomainBased.swift
@@ -1,6 +1,6 @@
 import ArgumentParser
 import Foundation
-@testable import PasswordGeneratorKit
+import PasswordGeneratorKit
 
 struct DomainBased: ParsableCommand {
 
@@ -18,25 +18,61 @@ struct DomainBased: ParsableCommand {
 
     func run() throws {
 
-        print(
-            """
-            key-length: \(options.keyLength)
-            key-iterations: \(options.keyIterations)
-            username: \(username)
-            domain: \(domain)
-            seed: \(seed)
-            length: \(options.length)
-            allowedCharacters: \(options.allowedCharacters)
-            """
-        )
+        let passwordGenerator: PasswordGenerator
+        switch options.entropySource {
+        case .pbkdf2:
+            passwordGenerator = PasswordGenerator(
+                masterPasswordProvider: options.masterPassword,
+                entropyGenerator: .pbkdf2(iterations: options.iterations),
+                bytes: options.entropy
+            )
 
-        print("\nGenerating password...\n")
+            if options.verbose {
+                print(
+                    """
+                    entropy-source: pbkdf2
+                        - iterations: \(options.iterations)
+                    entropy: \(options.entropy) B
+                    """
+                )
+            }
 
-        let passwordGenerator = PasswordGenerator(
-            masterPasswordProvider: options.masterPassword,
-            iterations: options.keyIterations,
-            bytes: options.keyLength
-        )
+        case .argon2:
+            passwordGenerator = PasswordGenerator(
+                masterPasswordProvider: options.masterPassword,
+                entropyGenerator: .argon2(
+                    iterations: options.iterations,
+                    memory: options.memory,
+                    threads: options.threads
+                ),
+                bytes: options.entropy
+            )
+            if options.verbose {
+                print(
+                """
+                entropy-source: argon2
+                    - iterations: \(options.iterations)
+                    - memory: \(options.memory) kB
+                    - threads: \(options.threads)
+                entropy: \(options.entropy) B
+                """
+                )
+            }
+        }
+
+        if options.verbose {
+            print(
+                """
+                username: \(username)
+                domain: \(domain)
+                seed: \(seed)
+                length: \(options.length)
+                allowed-characters: \(options.allowedCharacters.map(\.rawValue).joined(separator: ","))
+                """
+            )
+
+            print("\nGenerating password...\n")
+        }
 
         let generatedPassword = try passwordGenerator.generatePassword(
             username: username,
@@ -45,7 +81,10 @@ struct DomainBased: ParsableCommand {
             rules: Set(options.allowedCharacters.map { $0.asPasswordRule() }).union([.length(options.length)])
         )
 
-        print("Generated password is:")
+        if options.verbose {
+            print("Generated password is:")
+        }
+        
         print(generatedPassword)
     }
 }

--- a/Sources/CLI/EntropyGenerator.swift
+++ b/Sources/CLI/EntropyGenerator.swift
@@ -1,0 +1,8 @@
+import ArgumentParser
+import PasswordGeneratorKit
+
+public enum EntropyGenerator: String, ExpressibleByArgument {
+
+    case pbkdf2
+    case argon2
+}

--- a/Sources/CLI/PasswordGeneratorCLI.swift
+++ b/Sources/CLI/PasswordGeneratorCLI.swift
@@ -4,25 +4,42 @@ struct PasswordGeneratorCLI: ParsableCommand {
 
     struct Options: ParsableArguments {
 
-        @Option(name: .long, default: 1_000, help: "The number of iterations to be used to generate a PBKDF2 key")
-        var keyIterations: Int
+        @Option(name: .long, default: .pbkdf2, help: "The entropy source to be used")
+        var entropySource: EntropyGenerator
 
-        @Option(name: .long, default: 64, help: "The size in bytes of the PBKDF2 key")
-        var keyLength: Int
+        @Option(name: .shortAndLong, default: 1_000, help: "The number of iterations to be used by the entropy source")
+        var iterations: UInt
+
+        @Option(name: .shortAndLong, default: 16_384, help: "The memory cost in kilobytes to be used by Argon2 entropy source. Ignored if using PBKDF2")
+        var memory: UInt
+
+        @Option(name: .shortAndLong, default: 1, help: "The number of threads to be used by Argon2 entropy source. Ignored if using PBKDF2")
+        var threads: UInt
+
+        @Option(name: .long, default: 64, help: "The size in bytes of the generated entropy")
+        var entropy: UInt
         
-        @Option(name: .shortAndLong, help: "The master password to be used")
+        @Option(name: [.long, .customShort("p")], help: "The master password to be used")
         var masterPassword: String
         
         @Option(name: .shortAndLong, default: 16, help: "The length in characters of the generated password")
-        var length: Int
+        var length: UInt
 
         //swiftlint:disable:next line_length
         @Flag(help: "The charactes that must be used in the generated password, at least one must be specified. Any combinations of the flags may be specified and this will be defined as having at least one character of that character set")
         var allowedCharacters: [AllowedCharacters]
+
+        @Flag(name: .shortAndLong, help: "Prints extra info in the terminal")
+        var verbose: Bool
     }
 
     static var configuration: CommandConfiguration {
-
-        CommandConfiguration(subcommands: [SaltBased.self, ServiceBased.self, DomainBased.self])
+        CommandConfiguration(
+            commandName: "password-generator",
+            abstract: "Deterministic password generator.",
+            discussion: "A password generator which will detereministically generate random passwords. Will always generate the same passwords given the same input.",
+            version: "4.1.0",
+            subcommands: [SaltBased.self, ServiceBased.self, DomainBased.self]
+        )
     }
 }

--- a/Sources/CLI/ServiceBased.swift
+++ b/Sources/CLI/ServiceBased.swift
@@ -1,5 +1,5 @@
 import ArgumentParser
-@testable import PasswordGeneratorKit
+import PasswordGeneratorKit
 
 struct ServiceBased: ParsableCommand {
 
@@ -11,30 +11,69 @@ struct ServiceBased: ParsableCommand {
 
     func run() throws {
 
-        print(
-            """
-            key-length: \(options.keyLength)
-            key-iterations: \(options.keyIterations)
-            service: \(service)
-            length: \(options.length)
-            allowedCharacters: \(options.allowedCharacters)
-            """
-        )
+        let passwordGenerator: PasswordGenerator
+        switch options.entropySource {
+        case .pbkdf2:
+            passwordGenerator = PasswordGenerator(
+                masterPasswordProvider: options.masterPassword,
+                entropyGenerator: .pbkdf2(iterations: options.iterations),
+                bytes: options.entropy
+            )
 
-        print("\nGenerating password...\n")
+            if options.verbose {
+                print(
+                    """
+                    entropy-source: pbkdf2
+                        - iterations: \(options.iterations)
+                    entropy: \(options.entropy) B
+                    """
+                )
+            }
 
-        let passwordGenerator = PasswordGenerator(
-            masterPasswordProvider: options.masterPassword,
-            iterations: options.keyIterations,
-            bytes: options.keyLength
-        )
+        case .argon2:
+            passwordGenerator = PasswordGenerator(
+                masterPasswordProvider: options.masterPassword,
+                entropyGenerator: .argon2(
+                    iterations: options.iterations,
+                    memory: options.memory,
+                    threads: options.threads
+                ),
+                bytes: options.entropy
+            )
+            if options.verbose {
+                print(
+                """
+                entropy-source: argon2
+                    - iterations: \(options.iterations)
+                    - memory: \(options.memory) kB
+                    - threads: \(options.threads)
+                entropy: \(options.entropy) B
+                """
+                )
+            }
+        }
+
+        if options.verbose {
+            print(
+                """
+                service: \(service)
+                length: \(options.length)
+                allowed-characters: \(options.allowedCharacters.map(\.rawValue).joined(separator: ","))
+                """
+            )
+
+            print("\nGenerating password...\n")
+        }
         
         let generatedPassword = try passwordGenerator.generatePassword(
             service: service,
             rules: Set(options.allowedCharacters.map { $0.asPasswordRule() }).union([.length(options.length)])
         )
 
-        print("Generated password is:")
+        if options.verbose {
+            print("Generated password is:")
+        }
+        
         print(generatedPassword)
     }
 }

--- a/Sources/PasswordGeneratorKit/EntropyGenerator/Argon2BasedEntropyGenerator.swift
+++ b/Sources/PasswordGeneratorKit/EntropyGenerator/Argon2BasedEntropyGenerator.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Argon2Kit
+import UIntX
+
+final class Argon2BasedEntropyGenerator<BaseInteger>: EntropyGenerator
+where BaseInteger: FixedWidthInteger,
+      BaseInteger: UnsignedInteger {
+
+    let iterations: UInt
+    let bytes: UInt
+    let memory: UInt
+    let threads: UInt
+
+    init(
+        iterations: UInt = 3,
+        memory: UInt = 16_384,
+        threads: UInt = 1,
+        bytes: UInt = 64
+    ) {
+
+        self.iterations = iterations
+        self.memory = memory
+        self.threads = threads
+        self.bytes = bytes
+    }
+
+    func generateEntropy(with salt: String, masterPassword: String) throws -> UIntX<BaseInteger> {
+        let saltData: Data
+        if salt.count < 8 {
+            saltData = Data(Array("padded: \(salt)".utf8))
+        } else {
+            saltData = Data(Array(salt.utf8))
+        }
+
+        let digest = try Argon2.hash(
+            password: masterPassword,
+            salt: saltData,
+            iterations: UInt32(clamping: iterations),
+            memory: UInt32(clamping: memory),
+            threads: UInt32(clamping: threads),
+            length: UInt32(clamping: bytes),
+            type: .i,
+            version: .latest
+        )
+
+        let bytesArray = [UInt8](digest.rawData)
+
+        return UIntX<BaseInteger>(bigEndianArray: bytesArray)
+    }
+}
+

--- a/Sources/PasswordGeneratorKit/EntropyGenerator/PBKDF2BasedEntropyGenerator.swift
+++ b/Sources/PasswordGeneratorKit/EntropyGenerator/PBKDF2BasedEntropyGenerator.swift
@@ -5,12 +5,12 @@ final class PBKDF2BasedEntropyGenerator<BaseInteger>: EntropyGenerator
 where BaseInteger: FixedWidthInteger,
       BaseInteger: UnsignedInteger {
 
-    let iterations: Int
-    let bytes: Int
+    let iterations: UInt
+    let bytes: UInt
 
     init(
-        iterations: Int = 1_000,
-        bytes: Int = 64
+        iterations: UInt = 1_000,
+        bytes: UInt = 64
     ) {
 
         self.iterations = iterations
@@ -22,12 +22,12 @@ where BaseInteger: FixedWidthInteger,
         let key = try PKCS5.PBKDF2(
             password: Array(masterPassword.utf8),
             salt: Array(salt.utf8),
-            iterations: iterations,
-            keyLength: bytes,
-            variant: .sha256
+            iterations: Int(clamping: iterations),
+            keyLength: Int(clamping: bytes),
+            variant: .sha2(.sha256)
         )
         .calculate()
 
-        return UIntX<BaseInteger>(ascendingArray: key.reversed())
+        return UIntX<BaseInteger>(bigEndianArray: key)
     }
 }

--- a/Sources/PasswordGeneratorKit/Extensions/BinaryInteger+Extensions.swift
+++ b/Sources/PasswordGeneratorKit/Extensions/BinaryInteger+Extensions.swift
@@ -3,7 +3,7 @@ extension BinaryInteger {
     func consumeEntropy(
         generatedPassword: String,
         characters: String,
-        maxLength: Int
+        maxLength: UInt
     ) -> (password: String, remainingEntropy: Self) {
 
         guard generatedPassword.count < maxLength else { return (generatedPassword, self) }

--- a/Sources/PasswordGeneratorKit/GenericPasswordGenerator.swift
+++ b/Sources/PasswordGeneratorKit/GenericPasswordGenerator.swift
@@ -1,7 +1,7 @@
 final class GenericPasswordGenerator<Entropy: BinaryInteger> {
 
-    let masterPasswordProvider: MasterPasswordProvider
-    let entropyGenerator: AnyEntropyGenerator<Entropy>
+    private let masterPasswordProvider: MasterPasswordProvider
+    private let entropyGenerator: AnyEntropyGenerator<Entropy>
 
     init<Generator: EntropyGenerator>(
         masterPasswordProvider: MasterPasswordProvider,
@@ -62,7 +62,7 @@ final class GenericPasswordGenerator<Entropy: BinaryInteger> {
         var generatedPassword = ""
         var allowedCharacters = ""
         var extraCharacters = ""
-        var extraCount = 0
+        var extraCount: UInt = 0
         for case let .mustContain(characterSet, count) in rules.sorted() {
 
             allowedCharacters += characterSet

--- a/Sources/PasswordGeneratorKit/PasswordGenerator+Error.swift
+++ b/Sources/PasswordGeneratorKit/PasswordGenerator+Error.swift
@@ -1,11 +1,50 @@
+import Foundation
+
 public extension PasswordGenerator {
 
-    enum Error: Swift.Error {
+    enum Error: LocalizedError {
         
         case entropyGenerationError(Swift.Error)
         case mustSpecifyLength
         case mustSpecifyAtLeastOneCharacterSet
         case failedToFetchMasterPassword(Swift.Error)
+
+        public var errorDescription: String? {
+            switch self {
+            case .entropyGenerationError(let error):
+                return "Failed to generate entropy with: \(error.localizedDescription)"
+            case .mustSpecifyLength:
+                return "Password length must be specified"
+            case .mustSpecifyAtLeastOneCharacterSet:
+                return "Must specify at least one character set"
+            case .failedToFetchMasterPassword(let error):
+                return "Failed to fetch master password with: \(error.localizedDescription)"
+            }
+        }
+
+        public var failureReason: String? {
+            switch self {
+            case .entropyGenerationError(let error):
+                return error.localizedDescription
+            case .mustSpecifyLength:
+                return "Password length was not specified"
+            case .mustSpecifyAtLeastOneCharacterSet:
+                return "No character set was specified"
+            case .failedToFetchMasterPassword(let error):
+                return error.localizedDescription
+            }
+        }
+
+        public var recoverySuggestion: String? {
+            switch self {
+            case .entropyGenerationError, .failedToFetchMasterPassword:
+                return nil
+            case .mustSpecifyLength:
+                return "Specify password length"
+            case .mustSpecifyAtLeastOneCharacterSet:
+                return "Specify a character set to be used"
+            }
+        }
     }
 }
 

--- a/Sources/PasswordGeneratorKit/PasswordRule/PasswordRule+Defaults.swift
+++ b/Sources/PasswordGeneratorKit/PasswordRule/PasswordRule+Defaults.swift
@@ -1,5 +1,12 @@
 public extension PasswordRule {
 
+    enum CharacterSet {
+        public static let lowercase = String.lowercaseCharacters
+        public static let uppercase = String.uppercaseCharacters
+        public static let decimal = String.decimalCharacters
+        public static let symbol = String.symbolCharacters
+    }
+
     static let defaultLength = PasswordRule.length(16)
     
     static let defaultCharacterSet = Set<PasswordRule>([
@@ -9,22 +16,22 @@ public extension PasswordRule {
         .mustContain(characterSet: .symbolCharacters, atLeast: 1)
     ])
 
-    static func mustContainLowercaseCharacters(atLeast count: Int) -> PasswordRule {
+    static func mustContainLowercaseCharacters(atLeast count: UInt) -> PasswordRule {
 
         .mustContain(characterSet: .lowercaseCharacters, atLeast: count)
     }
 
-    static func mustContainUppercaseCharacters(atLeast count: Int) -> PasswordRule {
+    static func mustContainUppercaseCharacters(atLeast count: UInt) -> PasswordRule {
 
         .mustContain(characterSet: .uppercaseCharacters, atLeast: count)
     }
 
-    static func mustContainDecimalCharacters(atLeast count: Int) -> PasswordRule {
+    static func mustContainDecimalCharacters(atLeast count: UInt) -> PasswordRule {
 
         .mustContain(characterSet: .decimalCharacters, atLeast: count)
     }
 
-    static func mustContainSymbolCharacters(atLeast count: Int) -> PasswordRule {
+    static func mustContainSymbolCharacters(atLeast count: UInt) -> PasswordRule {
 
         .mustContain(characterSet: .symbolCharacters, atLeast: count)
     }

--- a/Sources/PasswordGeneratorKit/PasswordRule/PasswordRule.swift
+++ b/Sources/PasswordGeneratorKit/PasswordRule/PasswordRule.swift
@@ -1,5 +1,5 @@
 public enum PasswordRule {
 
-    case mustContain(characterSet: String, atLeast: Int)
-    case length(Int)
+    case mustContain(characterSet: String, atLeast: UInt)
+    case length(UInt)
 }

--- a/Tests/PasswordGeneratorKitTests/EntropyGeneratorTests.swift
+++ b/Tests/PasswordGeneratorKitTests/EntropyGeneratorTests.swift
@@ -22,7 +22,27 @@ final class EntropyGeneratorTests: XCTestCase {
         XCTAssertEqual(entropy4?.bitWidth, 256)
     }
 
+    func testArgon2EntropyGeneration() {
+
+        let generator = Argon2BasedEntropyGenerator<UInt64>(iterations: 1, memory: 4_096, threads: 1, bytes: 8)
+        let entropy = try? generator.generateEntropy(with: "salt", masterPassword: "password")
+        XCTAssertEqual(entropy?.bitWidth, 64)
+
+        let generator2 = Argon2BasedEntropyGenerator<UInt64>(iterations: 1, memory: 4_096, threads: 1, bytes: 16)
+        let entropy2 = try? generator2.generateEntropy(with: "salt", masterPassword: "password")
+        XCTAssertEqual(entropy2?.bitWidth, 128)
+
+        let generator3 = Argon2BasedEntropyGenerator<UInt64>(iterations: 1, memory: 4_096, threads: 1, bytes: 20)
+        let entropy3 = try? generator3.generateEntropy(with: "salt", masterPassword: "password")
+        XCTAssertEqual(entropy3?.bitWidth, 192)
+
+        let generator4 = Argon2BasedEntropyGenerator<UInt8>(iterations: 1, memory: 4_096, threads: 1, bytes: 32)
+        let entropy4 = try? generator4.generateEntropy(with: "salt", masterPassword: "password")
+        XCTAssertEqual(entropy4?.bitWidth, 256)
+    }
+
     static let allTests = [
-        ("testPBKDF2EntropyGeneration", testPBKDF2EntropyGeneration)
+        ("testPBKDF2EntropyGeneration", testPBKDF2EntropyGeneration),
+        ("testArgon2EntropyGeneration", testArgon2EntropyGeneration)
     ]
 }

--- a/Tests/PasswordGeneratorKitTests/Mocks/MockEntropyGenerators.swift
+++ b/Tests/PasswordGeneratorKitTests/Mocks/MockEntropyGenerators.swift
@@ -3,10 +3,19 @@ import UIntX
 
 final class UIntXEntropyGenerator: EntropyGenerator {
 
-    func generateEntropy(with salt: String, masterPassword: String) throws -> UIntX8 { UIntX8(UInt.max) }
+    private let entropy: UIntX8
+    init(entropy: UIntX8 = UIntX8(UInt.max)) {
+        self.entropy = entropy
+    }
+
+    func generateEntropy(with salt: String, masterPassword: String) throws -> UIntX8 { entropy }
 }
 
 final class UIntEntropyGenerator: EntropyGenerator {
 
-    func generateEntropy(with salt: String, masterPassword: String) throws -> UInt { UInt.max }
+    private let entropy: UInt
+    init(entropy: UInt = .max) {
+        self.entropy = entropy
+    }
+    func generateEntropy(with salt: String, masterPassword: String) throws -> UInt { entropy }
 }

--- a/Tests/PasswordGeneratorKitTests/PasswordGeneratorTests.swift
+++ b/Tests/PasswordGeneratorKitTests/PasswordGeneratorTests.swift
@@ -5,7 +5,7 @@ final class PasswordGeneratorTests: XCTestCase {
 
     func testSaltPasswordGeneration() {
 
-        let generator = PasswordGenerator(masterPasswordProvider: "masterPassword")
+        let generator = PasswordGenerator(masterPasswordProvider: "masterPassword", bytes: 64)
 
         XCTAssertEqual(
             try generator.generatePassword(salt: "salt", rules: PasswordRule.defaultRules),
@@ -13,9 +13,19 @@ final class PasswordGeneratorTests: XCTestCase {
         )
     }
 
+    func testSaltPasswordGenerationWithArgon2() {
+
+        let generator = PasswordGenerator(masterPasswordProvider: "masterPassword", entropyGenerator: .argon2(), bytes: 64)
+
+        XCTAssertEqual(
+            try generator.generatePassword(salt: "salt", rules: PasswordRule.defaultRules),
+            "-Zxrp4h2ttF-xRRu"
+        )
+    }
+
     func testUsernameDomainPasswordGeneration() {
 
-        let generator = PasswordGenerator(masterPasswordProvider: "masterPassword")
+        let generator = PasswordGenerator(masterPasswordProvider: "masterPassword", bytes: 64)
 
         XCTAssertEqual(
             try generator.generatePassword(
@@ -38,9 +48,34 @@ final class PasswordGeneratorTests: XCTestCase {
         )
     }
 
+    func testUsernameDomainPasswordGenerationWithArgon2() {
+
+        let generator = PasswordGenerator(masterPasswordProvider: "masterPassword", entropyGenerator: .argon2(), bytes: 64)
+
+        XCTAssertEqual(
+            try generator.generatePassword(
+                username: "rkreutz",
+                domain: "github.com",
+                seed: 1,
+                rules: PasswordRule.defaultRules
+            ),
+            "!Z$x.zspWIm6anmR"
+        )
+
+        XCTAssertEqual(
+            try generator.generatePassword(
+                username: "rkreutz",
+                domain: "github.com",
+                seed: 2,
+                rules: PasswordRule.defaultRules
+            ),
+            "kDzQpUYDcQO4toe_"
+        )
+    }
+
     func testServicePasswordGenerator() {
 
-        let generator = PasswordGenerator(masterPasswordProvider: "masterPassword")
+        let generator = PasswordGenerator(masterPasswordProvider: "masterPassword", bytes: 64)
 
         XCTAssertEqual(
             try generator.generatePassword(service: "Bank name", rules: PasswordRule.defaultRules),
@@ -48,9 +83,19 @@ final class PasswordGeneratorTests: XCTestCase {
         )
     }
 
+    func testServicePasswordGeneratorWithArgon2() {
+
+        let generator = PasswordGenerator(masterPasswordProvider: "masterPassword", entropyGenerator: .argon2(), bytes: 64)
+
+        XCTAssertEqual(
+            try generator.generatePassword(service: "Bank name", rules: PasswordRule.defaultRules),
+            "6NfR?T@qfsOFzVWo"
+        )
+    }
+
     func testRuleSetValidation() {
 
-        let generator = PasswordGenerator(masterPasswordProvider: "masterPassword")
+        let generator = PasswordGenerator(masterPasswordProvider: "masterPassword", bytes: 64)
 
         XCTAssertThrowsError(try generator.generatePassword(salt: "salt", rules: [])) { error in
 
@@ -73,7 +118,7 @@ final class PasswordGeneratorTests: XCTestCase {
 
     func testCharacterRules() {
 
-        let generator = PasswordGenerator(masterPasswordProvider: "masterPassword")
+        let generator = PasswordGenerator(masterPasswordProvider: "masterPassword", bytes: 64)
 
         XCTAssertEqual(
             try generator.generatePassword(
@@ -103,8 +148,11 @@ final class PasswordGeneratorTests: XCTestCase {
 
     static var allTests = [
         ("testSaltPasswordGeneration", testSaltPasswordGeneration),
+        ("testSaltPasswordGenerationWithArgon2", testSaltPasswordGenerationWithArgon2),
         ("testUsernameDomainPasswordGeneration", testUsernameDomainPasswordGeneration),
+        ("testUsernameDomainPasswordGenerationWithArgon2", testUsernameDomainPasswordGenerationWithArgon2),
         ("testServicePasswordGenerator", testServicePasswordGenerator),
+        ("testServicePasswordGeneratorWithArgon2", testServicePasswordGeneratorWithArgon2),
         ("testRuleSetValidation", testRuleSetValidation),
         ("testCharacterRules", testCharacterRules)
     ]

--- a/Tests/PasswordGeneratorKitTests/PerformanceTests.swift
+++ b/Tests/PasswordGeneratorKitTests/PerformanceTests.swift
@@ -4,42 +4,66 @@ import UIntX
 
 final class PerformanceTests: XCTestCase {
 
-    func test1000IterationsUIntX64() {
-
-        let generator = GenericPasswordGenerator<UIntX64>(
-            masterPasswordProvider: "masterPassword",
-            entropyGenerator: PBKDF2BasedEntropyGenerator(
-                iterations: 1_000,
-                bytes: 32
-            )
+    func testEntropyGenerator() {
+        let generator = Argon2BasedEntropyGenerator<UInt64>(
+            iterations: 3,
+            memory: 16_384,
+            threads: 1,
+            bytes: 24
         )
 
         measure {
-
             XCTAssertEqual(
-                try? generator.generatePassword(
-                    username: "rkreutz",
-                    domain: "github.com",
-                    seed: 1,
-                    rules: PasswordRule.defaultCharacterSet.union([PasswordRule.length(32)])
-                ),
-                "D&Wij1OxF-row84yvsz8BYE3UnmV3B%Q"
+                try? generator.generateEntropy(with: "salt", masterPassword: "masterPassword").bitWidth,
+                192
             )
         }
     }
 
-    func test100IterationsUIntX64() {
+    func testEntropyGeneratorAlt2() {
+        let generator = Argon2BasedEntropyGenerator<UInt64>(
+            iterations: 3,
+            memory: 16_384,
+            threads: 1,
+            bytes: 32
+        )
 
+        measure {
+            XCTAssertEqual(
+                try? generator.generateEntropy(with: "salt", masterPassword: "masterPassword").bitWidth,
+                256
+            )
+        }
+    }
+
+    func testEntropyGeneratorAlt3() {
+        let generator = Argon2BasedEntropyGenerator<UInt64>(
+            iterations: 3,
+            memory: 16_384,
+            threads: 1,
+            bytes: 64
+        )
+
+        measure {
+            XCTAssertEqual(
+                try? generator.generateEntropy(with: "salt", masterPassword: "masterPassword").bitWidth,
+                512
+            )
+        }
+    }
+
+    func testMostEntropy() {
         let generator = GenericPasswordGenerator<UIntX64>(
             masterPasswordProvider: "masterPassword",
-            entropyGenerator: PBKDF2BasedEntropyGenerator(
-                iterations: 100,
+            entropyGenerator: Argon2BasedEntropyGenerator(
+                iterations: 3,
+                memory: 16_384,
+                threads: 1,
                 bytes: 64
             )
         )
 
         measure {
-
             XCTAssertEqual(
                 try? generator.generatePassword(
                     username: "rkreutz",
@@ -47,23 +71,23 @@ final class PerformanceTests: XCTestCase {
                     seed: 1,
                     rules: PasswordRule.defaultCharacterSet.union([PasswordRule.length(32)])
                 ),
-                "yPGPRraFcXJ!Tk%1H3ib8RttZ0dZK#v!"
+                "$!Zx.sp6WImanmR5uEZEe06OFKM#QzFA"
             )
         }
     }
 
-    func test1000IterationsUIntX8() {
-
-        let generator = GenericPasswordGenerator<UIntX8>(
+    func testReasonableEntropy() {
+        let generator = GenericPasswordGenerator<UIntX64>(
             masterPasswordProvider: "masterPassword",
-            entropyGenerator: PBKDF2BasedEntropyGenerator(
-                iterations: 1_000,
-                bytes: 24
+            entropyGenerator: Argon2BasedEntropyGenerator(
+                iterations: 3,
+                memory: 16_384,
+                threads: 1,
+                bytes: 32
             )
         )
 
         measure {
-
             XCTAssertEqual(
                 try? generator.generatePassword(
                     username: "rkreutz",
@@ -71,23 +95,23 @@ final class PerformanceTests: XCTestCase {
                     seed: 1,
                     rules: PasswordRule.defaultCharacterSet.union([PasswordRule.length(32)])
                 ),
-                "nK4TQd%%zCc2m1cHjPJ%%G_i.W7@!zz3"
+                "AloP5-B77zZoY@l&!0qrwv1_zVLO.t?5"
             )
         }
     }
 
-    func test100IterationsUIntX8() {
-
-        let generator = GenericPasswordGenerator<UIntX8>(
+    func testMostEfficient() {
+        let generator = GenericPasswordGenerator<UIntX64>(
             masterPasswordProvider: "masterPassword",
-            entropyGenerator: PBKDF2BasedEntropyGenerator(
-                iterations: 100,
-                bytes: 24
+            entropyGenerator: Argon2BasedEntropyGenerator(
+                iterations: 3,
+                memory: 16_384,
+                threads: 1,
+                bytes: 24 // 24 gives best performance with 32 bytes max pwd length
             )
         )
 
         measure {
-
             XCTAssertEqual(
                 try? generator.generatePassword(
                     username: "rkreutz",
@@ -95,16 +119,9 @@ final class PerformanceTests: XCTestCase {
                     seed: 1,
                     rules: PasswordRule.defaultCharacterSet.union([PasswordRule.length(32)])
                 ),
-                "pB2U&Qz@wub@HPt4k5sJcYWThUo!Pzbq"
+                "tC1nlz?|cE.R-@b!1@zI8CbOneRv6Hm-"
             )
         }
     }
-
-    static var allTests = [
-        ("test1000IterationsUIntX64", test1000IterationsUIntX64),
-        ("test100IterationsUIntX64", test100IterationsUIntX64),
-        ("test1000IterationsUIntX8", test1000IterationsUIntX8),
-        ("test100IterationsUIntX8", test100IterationsUIntX8)
-    ]
 }
 

--- a/Tests/PasswordGeneratorKitTests/XCTestManifests.swift
+++ b/Tests/PasswordGeneratorKitTests/XCTestManifests.swift
@@ -5,8 +5,7 @@ public func allTests() -> [XCTestCaseEntry] {
     [
         testCase(EntropyGeneratorTests.allTests),
         testCase(PasswordGeneratorTests.allTests),
-        testCase(GenericPasswordGeneratorTests.allTests),
-        testCase(PerformanceTests.allTests)
+        testCase(GenericPasswordGeneratorTests.allTests)
     ]
 }
 #endif


### PR DESCRIPTION
# About
Added an Argon2 entropy generator, easily swappable with the current PBKDF2 entropy generator.

This is also updating `UIntX` to use the latest version, which has dramatic performance improvements (up to 75% reduction in computation time), this way we can leave the entropy generator (PBKDF2 or Argon2) as the main bulk of computation time (which is easily tweaked by the provided properties).

# How 
Relying on https://github.com/rkreutz/Argon2Kit we can then generate entropy from Argon2 hashing.

# Is it a breaking change?
No.
